### PR TITLE
Synchorinzed native library loading + version indenpendant pom

### DIFF
--- a/gael/openjpeg-imageio/pom.xml
+++ b/gael/openjpeg-imageio/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>fr.gael.openjpeg</groupId>
       <artifactId>openjpeg</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.1</version>
    </parent>
 
    <artifactId>openjpeg-imageio</artifactId>
@@ -28,7 +28,7 @@
       <dependency>
          <groupId>fr.gael.openjpeg</groupId>
          <artifactId>openjpeg-jni</artifactId>
-         <version>2.4.0</version>
+         <version>2.4.1</version>
       </dependency>
 
       <dependency>

--- a/gael/openjpeg-jni/pom.xml
+++ b/gael/openjpeg-jni/pom.xml
@@ -10,10 +10,11 @@
    <parent>
       <groupId>fr.gael.openjpeg</groupId>
       <artifactId>openjpeg</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.1</version>
    </parent>
 
    <artifactId>openjpeg-jni</artifactId>
+   <version>2.4.1</version>
    <packaging>jar</packaging>
 
    <properties>
@@ -21,6 +22,7 @@
       <maven.compiler.source>1.7</maven.compiler.source>
       <maven.compiler.target>1.7</maven.compiler.target>
       <log4j.version>2.1</log4j.version>
+      <openjpeg.native.version>2.4.0</openjpeg.native.version>
    </properties>
 
    <dependencies>
@@ -55,7 +57,7 @@
                         <artifactItem>
                            <groupId>fr.gael.openjpeg</groupId>
                            <artifactId>openjpeg-native</artifactId>
-                           <version>${project.version}</version>
+                           <version>${openjpeg.native.version}</version>
                            <classifier>${openjpeg.classifier}</classifier>
                            <type>${openjpeg.packaging}</type>
                            <overWrite>true</overWrite>

--- a/gael/openjpeg-jni/src/main/java/fr/gael/openjpeg/OpenJpegDecoder.java
+++ b/gael/openjpeg-jni/src/main/java/fr/gael/openjpeg/OpenJpegDecoder.java
@@ -10,14 +10,15 @@ import org.apache.log4j.Logger;
 public class OpenJpegDecoder
 {
 
-   private static final AtomicBoolean IS_INIT = new AtomicBoolean (false);
-
-   private static void loadLibraries ()
+   private static boolean loaded = false;
+   /**
+    * Performs library loading only once, and avoid
+    * concurrency calls.
+    */
+   private static synchronized void loadLibraries ()
    {
-      if (IS_INIT.getAndSet (true))
-      {
-         return;
-      }
+      // Library already loaded.
+      if (loaded) return;
 
       try
       {
@@ -27,6 +28,10 @@ public class OpenJpegDecoder
       {
          throw new IllegalStateException (
                "Cannot load OpenJpeg libraries", e);
+      }
+      finally
+      {
+         loaded=true;
       }
    }
 

--- a/gael/pom.xml
+++ b/gael/pom.xml
@@ -6,15 +6,22 @@
    <modelVersion>4.0.0</modelVersion>
 
    <name>GAEL Systems - OpenJpeg Suite</name>
+   <description>
+      This suite contains all the necessary library to access jp2k images.
+         - module "openjpeg-native" containes native C part to conect to the openjpeg library
+           (must ne carfully recompiled with correct libc)
+         - module "openjpeg-jni" is the JNI connector the the native jp2k library.
+         - module "openjpeg-imageio" is the imageio connector tu use JP2K in imageio API.
+   </description>
 
    <groupId>fr.gael.openjpeg</groupId>
    <artifactId>openjpeg</artifactId>
-   <version>2.4.0</version>
+   <version>2.4.1</version>
    <packaging>pom</packaging>
 
    <properties>
       <openjpeg.version>2.1.1</openjpeg.version>
-      <gael.repo.auth>#undefined#</gael.repo.auth>
+      <gael.repo.auth>gael-main</gael.repo.auth>
    </properties>
 
    <distributionManagement>
@@ -32,9 +39,15 @@
       </snapshotRepository>
    </distributionManagement>
 
+<!--
+   All the modules shall be compiled manually to better manage sub-modules versions.
+   This suite module is the parent of all the module, to it contains project configuration
+   but must not contain sub-modules versions.
+
    <modules>
       <module>openjpeg-native</module>
       <module>openjpeg-jni</module>
       <module>openjpeg-imageio</module>
    </modules>
+-->
 </project>


### PR DESCRIPTION
SD-1488 raised an issue regarding DHuS scanner image loading failure for a small set of the products ingested at the first run.
This was due to a concurrency conflict when library loading spent few seconds, the library was considered loaded even if the System.loadLibrary was not finished.

This PR also contains fix to reach best practice with maven modules and parent management. The version must be handled separately per modules. The parent pom shall contain only general settings.
This latter modification is required because the native library has not been modified and don't need to be recompiled. Attending the compilation requires specific libc library to be compatible with RedHat distribution.

So the parent suite is now 2.4.1 even if it continues to depend on native library 2.4.0.